### PR TITLE
feat: configure khome via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 ![GitHub Actions status](https://github.com/dennisschroeder/khome/workflows/Latest%20push/badge.svg)
-![LINE](https://img.shields.io/badge/line--coverage-15%25-red.svg)
+![LINE](https://img.shields.io/badge/line--coverage-19%25-red.svg)
 [![](https://jitpack.io/v/dennisschroeder/khome.svg)](https://jitpack.io/#dennisschroeder/khome)
 
 # Khome
@@ -115,8 +115,9 @@ I recommend using Kotlin with Intellij IDEA to get started. It's the best way to
 
 #### Initialization & Configuration
 
-To start listening to state change events and call services, you need to initialize and configure khome.
+To start listening to state change events and call services, you need to initialize and configure khome. Here you have three choices to configure khome
 
+1. The functional way
 ```kotlin
 khomeApplication { // this: Khome
     configure { // this: Configuration
@@ -127,6 +128,7 @@ khomeApplication { // this: Khome
      }
 }
 ```
+2. Use dependency injection
 Alternatively you can use a configuration bean.
 
 ```kotlin
@@ -135,13 +137,18 @@ data class MyConfiguration(
     override var port: Int = 8123,
     override var accessToken: String = "Your super secret token"
     override var secure = false
-) : Configuration()
+) : ConfigurationInterface
 
 khomeApplication { // this: Khome
     bean {
-        single<ConfigurationInterface> { MyConfiguration() }
+        single<ConfigurationInterface>(override = true) { MyConfiguration() }
     }
 }
+```
+3. Set environment variables
+You can use env variables to configure home.
+```.env
+HOST=192.169.178.101
 ```
 
 ##### Required Parameters

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,6 +85,15 @@ publishing {
 }
 
 tasks.withType<Test> {
+    environment["HOST"] = "home-assistant.local"
+    environment["PORT"] = 8321
+    environment["ACCESS_TOKEN"] = "dsq7zht54899dhz43kbv4dgr56a8we234h>!sg?x"
+    environment["SECURE"] = true
+    environment["START_STATE_STREAM"] = false
+    environment["LOG_LEVEL"] = "TRACE"
+    environment["LOG_TIME"] = false
+    environment["LOG_TIME_FORMAT"] = "yyy-MM-dd"
+    environment["LOG_OUTPUT"] = "/khome.log"
     useJUnitPlatform()
 }
 

--- a/src/main/kotlin/khome/Khome.kt
+++ b/src/main/kotlin/khome/Khome.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.coroutineScope
 import org.koin.core.get
 import org.koin.core.inject
+import org.koin.core.logger.Level
 import org.koin.core.module.Module
 import org.koin.dsl.module
 import java.util.concurrent.atomic.AtomicBoolean
@@ -105,6 +106,7 @@ internal fun KhomeSession.configureLogger(config: ConfigurationInterface) {
     System.setProperty(org.slf4j.impl.SimpleLogger.SHOW_DATE_TIME_KEY, "${config.logTime}")
     System.setProperty(org.slf4j.impl.SimpleLogger.DATE_TIME_FORMAT_KEY, config.logTimeFormat)
     System.setProperty(org.slf4j.impl.SimpleLogger.LOG_FILE_KEY, config.logOutput)
+    KhomeKoinContext.application?.let { it.printLogger(Level.valueOf(config.logLevel)) }
 }
 
 @KtorExperimentalAPI

--- a/src/main/kotlin/khome/core/Configuration.kt
+++ b/src/main/kotlin/khome/core/Configuration.kt
@@ -1,17 +1,5 @@
 package khome.core
 
-abstract class Configuration(
-    override var host: String = "localhost",
-    override var port: Int = 8123,
-    override var accessToken: String = "<create one in home-assistant>",
-    override var secure: Boolean = false,
-    override var startStateStream: Boolean = true,
-    override var logLevel: String = "INFO",
-    override var logTime: Boolean = true,
-    override var logTimeFormat: String = "yyyy-MM-dd HH:mm:ss",
-    override var logOutput: String = "System.out"
-) : ConfigurationInterface
-
 interface ConfigurationInterface {
     var host: String
     var port: Int

--- a/src/main/kotlin/khome/core/DefaultConfiguration.kt
+++ b/src/main/kotlin/khome/core/DefaultConfiguration.kt
@@ -1,3 +1,15 @@
 package khome.core
 
-class DefaultConfiguration : Configuration()
+import org.koin.core.logger.Level
+
+data class DefaultConfiguration(
+    override var host: String,
+    override var port: Int,
+    override var accessToken: String,
+    override var secure: Boolean,
+    override var startStateStream: Boolean,
+    override var logLevel: String,
+    override var logTime: Boolean,
+    override var logTimeFormat: String,
+    override var logOutput: String
+) : ConfigurationInterface

--- a/src/main/kotlin/khome/core/DefaultConfiguration.kt
+++ b/src/main/kotlin/khome/core/DefaultConfiguration.kt
@@ -1,7 +1,5 @@
 package khome.core
 
-import org.koin.core.logger.Level
-
 data class DefaultConfiguration(
     override var host: String,
     override var port: Int,

--- a/src/test/kotlin/khome/core/dependencyInjection/KhomeKoinContextTest.kt
+++ b/src/test/kotlin/khome/core/dependencyInjection/KhomeKoinContextTest.kt
@@ -1,0 +1,129 @@
+package khome.core.dependencyInjection
+
+import assertk.assertThat
+import assertk.assertions.isDataClassEqualTo
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isSuccess
+import assertk.assertions.isTrue
+import com.google.gson.Gson
+import khome.KhomeClient
+import khome.core.ConfigurationInterface
+import khome.core.DefaultConfiguration
+import khome.core.ServiceStore
+import khome.core.ServiceStoreInterface
+import khome.core.StateStore
+import khome.core.StateStoreInterface
+import khome.core.entities.AbstractEntity
+import khome.core.entities.Sun
+import khome.core.eventHandling.StateChangeEvent
+import khome.core.mapping.ObjectMapper
+import khome.core.mapping.ObjectMapperInterface
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.koin.core.get
+import org.koin.dsl.bind
+import org.koin.dsl.module
+import org.koin.test.check.checkModules
+import java.util.concurrent.atomic.AtomicInteger
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class KhomeKoinContextTest : KhomeComponent() {
+
+    private val sut = KhomeKoinContext
+
+    @BeforeEach
+    fun init() {
+        sut.startKoinApplication()
+    }
+
+    @Test
+    fun `assert khome components hierarchy is correct`() {
+        assertThat {
+            sut.application?.let {
+                it.checkModules()
+            }
+        }.isSuccess()
+    }
+
+    @Test
+    fun `assert all khome components are loaded and can be fetched`() {
+        assertThat {
+            val gson: Gson = get()
+
+            val stateStore: StateStoreInterface = get()
+            assertThat(stateStore).isInstanceOf(StateStore::class)
+
+            val serviceStore: ServiceStoreInterface = get()
+            assertThat(serviceStore).isInstanceOf(ServiceStore::class)
+
+            val objectMapperInterface: ObjectMapperInterface = get()
+            val objectMapperImplementation: ObjectMapper = get()
+
+            val stateChangeEvent: StateChangeEvent = get()
+            val failureResponseEvent: StateChangeEvent = get()
+
+            val serviceCoroutineContext: ServiceCoroutineContext = get()
+            assertThat(serviceCoroutineContext).isInstanceOf(ExecutorCoroutineDispatcher::class)
+
+            val callerID: CallerID = get()
+            assertThat(callerID).isInstanceOf(AtomicInteger::class)
+
+            val configuration: ConfigurationInterface = get()
+            assertThat(configuration).isInstanceOf(DefaultConfiguration::class)
+
+            val khomeClient: KhomeClient = get()
+
+            val sun: Sun = get()
+            assertThat(sun).isInstanceOf(AbstractEntity::class)
+        }.isSuccess()
+    }
+
+    @Test
+    fun `assert configuration bean can be overwritten`() {
+        data class CustomConfig(
+            override var host: String = "somehost.com",
+            override var port: Int = 1234,
+            override var accessToken: String = "some-super-secret-token",
+            override var secure: Boolean = true,
+            override var startStateStream: Boolean = true,
+            override var logLevel: String = "INFO",
+            override var logTime: Boolean = false,
+            override var logTimeFormat: String = "does not matter",
+            override var logOutput: String = "default"
+        ) : ConfigurationInterface
+
+        val testModule = module {
+            single<ConfigurationInterface>(override = true) { CustomConfig() } bind CustomConfig::class
+        }
+
+        loadKhomeModule(testModule)
+
+        val customConfig: CustomConfig = get()
+        assertThat(customConfig).isDataClassEqualTo(CustomConfig())
+    }
+
+    @Test
+    fun `assert environment variables are loaded via koin in configuration`() {
+        val config: ConfigurationInterface = get()
+
+        assertThat(config.host).isEqualTo("home-assistant.local")
+        assertThat(config.port).isEqualTo(8321)
+        assertThat(config.accessToken).isEqualTo("dsq7zht54899dhz43kbv4dgr56a8we234h>!sg?x")
+        assertThat(config.secure).isTrue()
+        assertThat(config.startStateStream).isFalse()
+        assertThat(config.logLevel).isEqualTo("TRACE")
+        assertThat(config.logTime).isFalse()
+        assertThat(config.logTimeFormat).isEqualTo("yyy-MM-dd")
+        assertThat(config.logOutput).isEqualTo("/khome.log")
+    }
+
+    @AfterEach
+    fun close() {
+        sut.application?.let { it.close() }
+    }
+}


### PR DESCRIPTION
Enables one to configure Khome via environment variables. Useful for injecting secrets and other dynamic values into Khome.